### PR TITLE
Change the way appendXp and appendLevel work.

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ class DiscordXp {
       return (Math.floor(0.1 * Math.sqrt(xp)) > 0);
     };
 
-    user.xp += xp;
+    user.xp += parseInt(xp, 10);
     user.level = Math.floor(0.1 * Math.sqrt(user.xp));
 
     await user.save().catch(e => console.log(`Failed to append xp: ${e}`) );
@@ -103,8 +103,8 @@ class DiscordXp {
 
     const user = await levels.findOne({ userID: userId, guildID: guildId });
     if (!user) return false;
-
-    user.level += levelss;
+    
+    user.level += parseInt(levelss, 10);
     user.xp = user.level * user.level * 100;
 
     user.save().catch(e => console.log(`Failed to append level: ${e}`) );


### PR DESCRIPTION
I recently found that this your functions (appendLevel, appendXp) will be broke as the amount params passed is string.  Example, current xp is 300:
appendXp(userid, guildid, '10')  // 30010
appendXp(userid, guildid, 10)  // 310
So i tried to fix this globally by parsing the amount before adding.