### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Promise<Array [Objects]>
 
 It returns a new array of object that include level, xp, guild id, user id, leaderboard position, username and discriminator.
 ```js
-Levels.fetch(<Client - Discord.js Client>, <Leaderboard - fetchLeaderboard output>);
+Levels.fetch(<Client - Discord.js Client>, <Leaderboard - fetchLeaderboard output>, <fetchUsers - boolean, disabled by default>);
 ```
 - Output:
 ```


### PR DESCRIPTION
computeLeaderboard Was updated recently and takes now a third boolean parameter fetchUsers.
It is already used in the example but it's missing in the documentation.
This pull request adds the missing parameter to the documentation.